### PR TITLE
Add ability to set default scope when role does not return valid query

### DIFF
--- a/lib/papers_please/policy.rb
+++ b/lib/papers_please/policy.rb
@@ -8,6 +8,7 @@ module PapersPlease
 
     def initialize(user)
       @user          = user
+      @default_scope = nil
       @roles         = {}
       @cache         = {}
 
@@ -16,6 +17,10 @@ module PapersPlease
 
     def allow_fallthrough
       @fallthrough = true
+    end
+
+    def default_scope(scope)
+      @default_scope = scope
     end
 
     def configure
@@ -100,7 +105,7 @@ module PapersPlease
         return scope
       end
 
-      nil
+      @default_scope || nil
     end
     alias query scope_for
 

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe PapersPlease::Policy do
         expect(owner_member).to have_received(:spy_method)
         expect(Post).to have_received(:spy_method)
       end
+
+      it 'allows you to define a default scope when no role matches the query' do
+        klass = Class.new(PapersPlease::Policy) do
+          def configure
+            role :admin, (proc { |u| u.admin })
+            role :member
+
+            permit :admin do |role|
+              role.grant :read, Post, query: (proc { Post.all })
+            end
+
+            default_scope :default_scope
+          end
+        end
+
+        expect(klass.new(member).scope_for(:read, Post)).to eq :default_scope
+      end
     end
   end
 


### PR DESCRIPTION
Without configuration:

```
policy.query(:thing, Foo) # => nil
```

With configuration:

```
policy.query(:thing, Foo) # => your default scope
```